### PR TITLE
feat: commit transcripts automatically

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -23,6 +25,13 @@ jobs:
           pip install mkdocs mkdocs-material
       - name: Sync transcripts (all videos)
         run: python scripts/sync.py
+      - name: Commit transcripts
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/transcripts
+          git commit -m "chore: update transcripts" || echo "No changes"
+          git push origin HEAD:main
       - name: Build site
         run: mkdocs build --strict
       - name: Publish to GitHub Pages


### PR DESCRIPTION
## Summary
- automatically commit fetched transcripts back to `main`
- ensure full git history is available for pushes

## Testing
- `yamllint .github/workflows/sync.yml` (warnings only)
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_b_68992c25886883218e2d77d3309e399e