### PR TITLE
feat: add CLI options for sync script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,23 @@
 
 This repository automatically mirrors videos from the [UAPGerb](https://www.youtube.com/@UAPGerb) YouTube channel.
 Transcripts are fetched with `yt-dlp` and `youtube-transcript-api` and published as a static site built by [MkDocs Material](https://squidfunk.github.io/mkdocs-material/).
+
+## Usage
+
+Sync the default UAPGerb channel into `docs/transcripts`:
+
+```bash
+python scripts/sync.py
+```
+
+Specify a different channel or output directory:
+
+```bash
+python scripts/sync.py --channel https://www.youtube.com/@OtherChannel --output-dir docs/other
+```
+
+Limit the number of videos processed:
+
+```bash
+python scripts/sync.py --max-videos 5
+```


### PR DESCRIPTION
## Summary
- add argparse-based CLI to scripts/sync.py
- allow overriding channel, output directory, and optional max videos
- document sync script usage in README

## Testing
- `python -m py_compile scripts/sync.py`
- `python scripts/sync.py --help`


------
https://chatgpt.com/codex/tasks/task_b_6899319d70e48321bd76afed7c34ce65